### PR TITLE
Implement Renan Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python
+__pycache__/
+*.pyc
+
+# Outputs
+outputs/
+chat_history.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# Jarvis
+# Renan Agent
+
+Renan Agent é um assistente local inspirado no Jarvis capaz de executar tarefas automaticamente utilizando ferramentas instaladas no computador.
+
+## Instalação
+
+1. Clone este repositório e navegue até a pasta do projeto.
+2. Execute o script `install.sh` para instalar as dependências Python:
+
+```bash
+./install.sh
+```
+
+Certifique-se de que ComfyUI, FFmpeg, n8n e Wav2Lip estejam instalados e presentes no `PATH` do sistema.
+
+## Uso
+
+Execute o agente com o comando abaixo:
+
+```bash
+python -m renan_agent.main
+```
+
+Digite seus comandos em português, por exemplo:
+
+- `gere uma imagem de uma paisagem`
+- `crie uma voz dizendo Olá`
+- `executar automacao exemplo`
+
+O histórico de conversa será salvo em `chat_history.txt`.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Simple installer for Renan Agent dependencies
+pip install -r requirements.txt

--- a/renan_agent/__init__.py
+++ b/renan_agent/__init__.py
@@ -1,0 +1,3 @@
+"""Pacote principal do Renan Agent."""
+
+__all__ = ["main"]

--- a/renan_agent/chat.py
+++ b/renan_agent/chat.py
@@ -1,0 +1,21 @@
+"""Simple conversation history management."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+class ChatHistory:
+    """In-memory chat history."""
+
+    def __init__(self) -> None:
+        self.history: List[str] = []
+
+    def add_user_message(self, message: str) -> None:
+        self.history.append(f"Usuário: {message}")
+
+    def add_agent_message(self, message: str) -> None:
+        self.history.append(f"Renan: {message}")
+
+    def get_history(self) -> str:
+        return "\n".join(self.history)

--- a/renan_agent/main.py
+++ b/renan_agent/main.py
@@ -1,0 +1,54 @@
+"""Main entry point for Renan Agent.
+Provides a simple command-line chat interface for executing tasks.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, Dict
+
+from .chat import ChatHistory
+from .modules import image, video, transcription, voice, automation
+
+# Mapping of keywords to module handlers
+COMMAND_HANDLERS: Dict[str, Callable[[str], str]] = {
+    "imagem": image.generate_image,
+    "video": video.create_video,
+    "transcrever": transcription.transcribe_audio,
+    "voz": voice.synthesize_voice,
+    "automacao": automation.run_flow,
+}
+
+def parse_command(command: str) -> Callable[[str], str] | None:
+    """Return the handler for a given command text."""
+    for key, handler in COMMAND_HANDLERS.items():
+        if key in command.lower():
+            return handler
+    return None
+
+def main() -> None:
+    """Run a simple REPL chat for the agent."""
+    chat = ChatHistory()
+    print("Renan Agent iniciado. Digite 'sair' para encerrar.")
+    while True:
+        try:
+            user_input = input("Você: ")
+        except EOFError:
+            break
+        if user_input.strip().lower() == "sair":
+            break
+        chat.add_user_message(user_input)
+        handler = parse_command(user_input)
+        if handler:
+            response = handler(user_input)
+        else:
+            response = "Comando não reconhecido."
+        chat.add_agent_message(response)
+        print(f"Renan: {response}")
+    # Optionally save conversation history
+    history_path = Path("chat_history.txt")
+    history_path.write_text("\n".join(chat.history))
+
+if __name__ == "__main__":
+    main()

--- a/renan_agent/modules/__init__.py
+++ b/renan_agent/modules/__init__.py
@@ -1,0 +1,5 @@
+"""Module exports for Renan Agent integrations."""
+
+from . import image, video, transcription, voice, automation
+
+__all__ = ["image", "video", "transcription", "voice", "automation"]

--- a/renan_agent/modules/automation.py
+++ b/renan_agent/modules/automation.py
@@ -1,0 +1,15 @@
+"""n8n automation integration."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def run_flow(command: str) -> str:
+    """Run an n8n workflow."""
+    flow_name = command.replace("executar automacao", "").strip()
+    try:
+        subprocess.run(["n8n", "run", flow_name], check=True)
+        return f"Fluxo {flow_name} executado"
+    except Exception as exc:  # pylint: disable=broad-except
+        return f"Falha ao executar automação: {exc}"

--- a/renan_agent/modules/image.py
+++ b/renan_agent/modules/image.py
@@ -1,0 +1,23 @@
+"""Image generation via ComfyUI."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def generate_image(command: str) -> str:
+    """Generate an image using ComfyUI.
+
+    This function assumes ComfyUI is installed locally and accessible
+    via the `comfyui` command. The generated image path is returned.
+    """
+    prompt = command.replace("gere uma imagem", "").strip()
+    output_dir = Path("outputs")
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / "image.png"
+    try:
+        subprocess.run(["comfyui", "--prompt", prompt, "--output", str(output_path)], check=True)
+        return f"Imagem gerada em {output_path}"
+    except Exception as exc:  # pylint: disable=broad-except
+        return f"Falha ao gerar imagem: {exc}"

--- a/renan_agent/modules/transcription.py
+++ b/renan_agent/modules/transcription.py
@@ -1,0 +1,19 @@
+"""Audio transcription using Whisper."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def transcribe_audio(command: str) -> str:
+    """Transcribe audio using Whisper."""
+    output_dir = Path("outputs")
+    output_dir.mkdir(exist_ok=True)
+    audio_path = output_dir / "audio.wav"
+    transcript_path = output_dir / "transcript.txt"
+    try:
+        subprocess.run(["whisper", str(audio_path), "--output", str(transcript_path)], check=True)
+        return transcript_path.read_text()
+    except Exception as exc:  # pylint: disable=broad-except
+        return f"Falha na transcrição: {exc}"

--- a/renan_agent/modules/video.py
+++ b/renan_agent/modules/video.py
@@ -1,0 +1,20 @@
+"""Video creation utilities using FFmpeg and Wav2Lip."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def create_video(command: str) -> str:
+    """Create a video from an image and audio using Wav2Lip."""
+    output_dir = Path("outputs")
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / "video.mp4"
+    image_path = output_dir / "image.png"
+    audio_path = output_dir / "audio.wav"
+    try:
+        subprocess.run(["wav2lip", "--face", str(image_path), "--audio", str(audio_path), "--outfile", str(output_path)], check=True)
+        return f"Vídeo criado em {output_path}"
+    except Exception as exc:  # pylint: disable=broad-except
+        return f"Falha ao criar vídeo: {exc}"

--- a/renan_agent/modules/voice.py
+++ b/renan_agent/modules/voice.py
@@ -1,0 +1,19 @@
+"""Voice synthesis using Coqui TTS."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def synthesize_voice(command: str) -> str:
+    """Generate synthetic speech using Coqui TTS."""
+    text = command.replace("crie uma voz", "").strip()
+    output_dir = Path("outputs")
+    output_dir.mkdir(exist_ok=True)
+    audio_path = output_dir / "audio.wav"
+    try:
+        subprocess.run(["tts", "--text", text, "--out_path", str(audio_path)], check=True)
+        return f"Áudio gerado em {audio_path}"
+    except Exception as exc:  # pylint: disable=broad-except
+        return f"Falha na geração de voz: {exc}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ffmpeg-python
+openai-whisper
+TTS
+pyn8n


### PR DESCRIPTION
## Summary
- replace default README with instructions for Renan Agent
- add installation script and Python requirements
- implement Renan Agent modules for image, video, voice, transcription and n8n automation
- create chat history helper and command line interface
- ignore generated files

## Testing
- `python -m renan_agent.main` *(interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_688b92fc3170832bb0be6f81fe30ae5f